### PR TITLE
Rebase Docker Image to linuxserver-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-mono:LTS
+FROM ghcr.io/linuxserver/baseimage-alpine:3.15
 LABEL maintainer="mdhiggins <mdhiggins23@gmail.com>"
 
 ENV PAS_PATH /usr/local/pas
@@ -6,11 +6,12 @@ ENV PAS_UPDATE false
 
 # get python3 and git, and install python libraries
 RUN \
-  apt-get update && \
-  apt-get install -y \
+  apk add --no-cache \
     git \
     python3 \
-    python3-pip && \
+    py3-pip && \
+# symlink python3 for compatibility
+  ln -s /usr/bin/python3 /usr/bin/python && \
 # make directory
   mkdir ${PAS_PATH} && \
 # download repo
@@ -23,12 +24,10 @@ RUN \
 # link config
   ln -s /config ${PAS_PATH}/config && \
 # cleanup
-  apt-get purge --auto-remove -y && \
-  apt-get clean && \
+  apk del --purge && \
   rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/*
+    /root/.cache \
+    /tmp/*
 
 VOLUME /config
 


### PR DESCRIPTION
Noticed that the docker image was quite large when downloading and saw you were using the the ubuntu image with mono built-in. [Mono](https://www.mono-project.com/) is really only really needed if you are running something on `.Net` like Sonarr, Radarr, etc. Otherwise it's really just bloat if you don't need it. Same with a full Ubuntu image. I think for something like a python program the `alpine` image should be enough. 

Switching to `alpine` brought the image size from 886mb to ~147mb for me and it seems to be working fine for my quick testing.

You can check the test image I built here
`ghcr.io/tchilderhose/plexautoskip-docker:master`

Anyways, thanks for your work on this again and for your work on SMA.